### PR TITLE
Fix crash with NotEnoughItems (GTNH version), Licensing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,9 +62,9 @@ ext.configFile.withReader {
 
 ext.minecraft_version = config.minecraft_version
 ext.forge_version = config.forge_version
-ext.codechickenlib = "codechicken:CodeChickenLib:${config.minecraft_version}-${config.CCLIB_version}:dev"
-ext.codechickencore = "codechicken:CodeChickenCore:${config.minecraft_version}-${config.CCC_version}:dev"
-ext.notenoughitems = "codechicken:NotEnoughItems:${config.minecraft_version}-${config.NEI_version}:dev"
+ext.codechickenlib = "com.github.GTNewHorizons:CodeChickenLib:${config.CCLIB_version}:dev"
+ext.codechickencore = "com.github.GTNewHorizons:CodeChickenCore:${config.CCC_version}:dev"
+ext.notenoughitems = "com.github.GTNewHorizons:NotEnoughItems:${config.NEI_version}:dev"
 
 println "$project.name for Forge: " + minecraft_version + "-" + forge_version
 

--- a/build.gradle
+++ b/build.gradle
@@ -109,3 +109,10 @@ processResources {
         exclude '*.version'
     }
 }
+
+// Jar stuff
+jar {
+    manifest {
+        attributes 'AccessTransformer': 'spacore_at.cfg'
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
         maven {
             name = "forge"
-            url = "http://files.minecraftforge.net/maven"
+            url = "https://maven.minecraftforge.net/"
         }
         maven {
             name = "sonatype"
@@ -11,7 +11,9 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:1.2-SNAPSHOT'
+        classpath ('com.anatawa12.forge:ForgeGradle:1.2-1.1.+') {
+            changing = true
+        }
     }
 }
 
@@ -26,7 +28,7 @@ repositories {
     }
     maven {
         name 'ForgeFS'
-        url 'http://files.minecraftforge.net/maven'
+        url "https://maven.minecraftforge.net/"
     }
     maven {
         name 'MinecraftS3'

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,10 @@ repositories {
         name 'MinecraftS3'
         url 'http://s3.amazonaws.com/Minecraft.Download/libraries'
     }
+    maven {
+        name = "gtnh"
+        url = uri("https://nexus.gtnewhorizons.com/repository/public/")
+    }
 }
 
 apply plugin: 'idea'
@@ -45,8 +49,8 @@ idea {
 
 apply plugin: 'forge'
 
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 ext.configFile = file "build.properties"
 ext.configFile.withReader {

--- a/build.properties
+++ b/build.properties
@@ -1,9 +1,9 @@
 minecraft_version=1.7.10
-forge_version=10.13.4.1448
+forge_version=10.13.4.1614
 
-NEI_version=1.0.3.74
-CCLIB_version=1.1.3.140
-CCC_version=1.0.4.29
+NEI_version=2.7.77-GTNH
+CCLIB_version=1.3.0
+CCC_version=1.4.7
 
 super_number=02
 major_number=01

--- a/build.properties
+++ b/build.properties
@@ -6,5 +6,5 @@ CCLIB_version=1.3.0
 CCC_version=1.4.7
 
 super_number=02
-major_number=01
-minor_number=08
+major_number=02
+minor_number=03

--- a/build.properties
+++ b/build.properties
@@ -7,4 +7,4 @@ CCC_version=1.4.7
 
 super_number=02
 major_number=02
-minor_number=03
+minor_number=04

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-bin.zip

--- a/src/main/java/me/heldplayer/plugins/nei/mystcraft/client/AgeExplorerRecipeHandler.java
+++ b/src/main/java/me/heldplayer/plugins/nei/mystcraft/client/AgeExplorerRecipeHandler.java
@@ -120,7 +120,7 @@ public class AgeExplorerRecipeHandler extends TemplateRecipeHandler {
             recipe.view = LGView.api.createWorldView(recipe.ageInfo.dimId, recipe.ageInfo.spawn, 384, 216);
             recipe.view.setAnimator(new CameraAnimatorPivot(recipe.view.getCamera()) {
                 @Override
-                public void update(float dt) {
+                public void update(long dt) {
                     if (!NEIClientUtils.shiftKey()) {
                         super.update(dt);
                     }
@@ -159,9 +159,8 @@ public class AgeExplorerRecipeHandler extends TemplateRecipeHandler {
         return 1;
     }
 
-    @Override
-    public List<String> handleTooltip(GuiRecipe gui, List<String> currenttip, int recipeId) {
-        CachedBooksRecipe recipe = (CachedBooksRecipe) this.arecipes.get(recipeId);
+    public List<String> handleTooltip(GuiRecipe gui, List<String> currenttip, int recipeId, int recipeId2) {
+        /*CachedBooksRecipe recipe = (CachedBooksRecipe) this.arecipes.get(recipeId);
 
         Point mousepos = GuiDraw.getMousePosition();
         Point relMouse = new Point(mousepos.x - gui.guiLeft - 5, mousepos.y - gui.guiTop - 16);
@@ -231,7 +230,7 @@ public class AgeExplorerRecipeHandler extends TemplateRecipeHandler {
 
             recipe.scroll();
         }
-
+		*/
         return super.handleTooltip(gui, currenttip, recipeId);
     }
 

--- a/src/main/java/me/heldplayer/plugins/nei/mystcraft/client/AgeExplorerRecipeHandler.java
+++ b/src/main/java/me/heldplayer/plugins/nei/mystcraft/client/AgeExplorerRecipeHandler.java
@@ -159,8 +159,9 @@ public class AgeExplorerRecipeHandler extends TemplateRecipeHandler {
         return 1;
     }
 
-    public List<String> handleTooltip(GuiRecipe gui, List<String> currenttip, int recipeId, int recipeId2) {
-        /*CachedBooksRecipe recipe = (CachedBooksRecipe) this.arecipes.get(recipeId);
+    @Override
+    public List<String> handleTooltip(GuiRecipe<?> gui, List<String> currenttip, int recipeId) {
+        CachedBooksRecipe recipe = (CachedBooksRecipe) this.arecipes.get(recipeId);
 
         Point mousepos = GuiDraw.getMousePosition();
         Point relMouse = new Point(mousepos.x - gui.guiLeft - 5, mousepos.y - gui.guiTop - 16);

--- a/src/main/java/me/heldplayer/plugins/nei/mystcraft/client/AgeExplorerRecipeHandler.java
+++ b/src/main/java/me/heldplayer/plugins/nei/mystcraft/client/AgeExplorerRecipeHandler.java
@@ -231,7 +231,7 @@ public class AgeExplorerRecipeHandler extends TemplateRecipeHandler {
 
             recipe.scroll();
         }
-		*/
+
         return super.handleTooltip(gui, currenttip, recipeId);
     }
 

--- a/src/main/java/me/heldplayer/plugins/nei/mystcraft/client/InkMixerRecipeHandler.java
+++ b/src/main/java/me/heldplayer/plugins/nei/mystcraft/client/InkMixerRecipeHandler.java
@@ -210,14 +210,13 @@ public class InkMixerRecipeHandler extends TemplateRecipeHandler {
         return 1;
     }
 
-    @Override
-    public List<String> handleItemTooltip(GuiRecipe gui, ItemStack stack, List<String> currenttip, int recipeId) {
+    public List<String> handleItemTooltip(GuiRecipe gui, ItemStack stack, List<String> currenttip, int recipeId, int recipeId2) {
         currenttip = super.handleItemTooltip(gui, stack, currenttip, recipeId);
 
         if (!ModuleTooltips.inkMixerTooltips || !ModuleRecipes.inkMixerEnabled) {
             return currenttip;
         }
-
+        
         Point mousepos = GuiDraw.getMousePosition();
         Point relMouse = new Point(mousepos.x - gui.guiLeft, mousepos.y - gui.guiTop);
 

--- a/src/main/java/me/heldplayer/plugins/nei/mystcraft/client/InkMixerRecipeHandler.java
+++ b/src/main/java/me/heldplayer/plugins/nei/mystcraft/client/InkMixerRecipeHandler.java
@@ -210,8 +210,9 @@ public class InkMixerRecipeHandler extends TemplateRecipeHandler {
         return 1;
     }
 
-    public List<String> handleItemTooltip(GuiRecipe gui, ItemStack stack, List<String> currenttip, int recipeId, int recipeId2) {
-        currenttip = super.handleItemTooltip(gui, stack, currenttip, recipeId);
+    @Override
+    public List<String> handleItemTooltip(GuiRecipe<?> gui, ItemStack stack, List<String> currenttip, int recipe) {
+        currenttip = super.handleItemTooltip(gui, stack, currenttip, recipe);
 
         if (!ModuleTooltips.inkMixerTooltips || !ModuleRecipes.inkMixerEnabled) {
             return currenttip;

--- a/src/main/java/me/heldplayer/plugins/nei/mystcraft/client/InkMixerRecipeHandler.java
+++ b/src/main/java/me/heldplayer/plugins/nei/mystcraft/client/InkMixerRecipeHandler.java
@@ -211,13 +211,13 @@ public class InkMixerRecipeHandler extends TemplateRecipeHandler {
     }
 
     @Override
-    public List<String> handleItemTooltip(GuiRecipe<?> gui, ItemStack stack, List<String> currenttip, int recipe) {
-        currenttip = super.handleItemTooltip(gui, stack, currenttip, recipe);
+    public List<String> handleItemTooltip(GuiRecipe<?> gui, ItemStack stack, List<String> currenttip, int recipeId) {
+        currenttip = super.handleItemTooltip(gui, stack, currenttip, recipeId);
 
         if (!ModuleTooltips.inkMixerTooltips || !ModuleRecipes.inkMixerEnabled) {
             return currenttip;
         }
-        
+
         Point mousepos = GuiDraw.getMousePosition();
         Point relMouse = new Point(mousepos.x - gui.guiLeft, mousepos.y - gui.guiTop);
 

--- a/src/main/java/me/heldplayer/plugins/nei/mystcraft/client/MystTooltipHandler.java
+++ b/src/main/java/me/heldplayer/plugins/nei/mystcraft/client/MystTooltipHandler.java
@@ -20,7 +20,7 @@ public class MystTooltipHandler implements IContainerInputHandler, IContainerToo
 
     @Override
     public List<String> handleTooltip(GuiContainer gui, int mousex, int mousey, List<String> currenttip) {
-        if (ModuleTooltips.recipesTooltips && Integrator.guiWritingDeskClass.isAssignableFrom(gui.getClass())) {
+        /*if (ModuleTooltips.recipesTooltips && Integrator.guiWritingDeskClass.isAssignableFrom(gui.getClass())) {
             Point mousepos = GuiDraw.getMousePosition();
             Point relMouse = new Point(mousepos.x - gui.guiLeft, mousepos.y - gui.guiTop);
 
@@ -38,7 +38,7 @@ public class MystTooltipHandler implements IContainerInputHandler, IContainerToo
             if (currenttip.isEmpty() && GuiContainerManager.shouldShowTooltip(gui) && center.distance(relMouse) < 34.0D) {
                 currenttip.add(StatCollector.translateToLocal("nei.mystcraft.recipes"));
             }
-        }
+        }*/
         return currenttip;
     }
 
@@ -51,7 +51,7 @@ public class MystTooltipHandler implements IContainerInputHandler, IContainerToo
     public List<String> handleItemTooltip(GuiContainer gui, ItemStack stack, int mouseX, int mouseY, List<String> currenttip) {
         if (gui instanceof GuiRecipe) {
             Point mousepos = new Point(mouseX, mouseY);
-            Point relMouse = new Point(mousepos.x - gui.guiLeft, mousepos.y - gui.guiTop);
+            /*Point relMouse = new Point(mousepos.x - gui.guiLeft, mousepos.y - gui.guiTop);
 
             GuiRecipe guiRecipe = (GuiRecipe) gui;
 
@@ -67,7 +67,7 @@ public class MystTooltipHandler implements IContainerInputHandler, IContainerToo
                         currenttip.add(StatCollector.translateToLocal("nei.mystcraft.recipes"));
                     }
                 }
-            }
+            }*/
         }
         return currenttip;
     }
@@ -76,7 +76,7 @@ public class MystTooltipHandler implements IContainerInputHandler, IContainerToo
     public boolean keyTyped(GuiContainer gui, char keyChar, int keyCode) {
         if (Integrator.guiWritingDeskClass.isAssignableFrom(gui.getClass())) {
             Point mousepos = GuiDraw.getMousePosition();
-            Point relMouse = new Point(mousepos.x - gui.guiLeft, mousepos.y - gui.guiTop);
+            /*Point relMouse = new Point(mousepos.x - gui.guiLeft, mousepos.y - gui.guiTop);
 
             Rectangle rect = new Rectangle(156 + 228, 45, 18, 34);
 
@@ -88,10 +88,10 @@ public class MystTooltipHandler implements IContainerInputHandler, IContainerToo
                     GuiUsageRecipe.openRecipeGui("writingdesk");
                     return true;
                 }
-            }
+            }*/
         } else if (Integrator.guiInkMixerClass.isAssignableFrom(gui.getClass())) {
             Point mousepos = GuiDraw.getMousePosition();
-            Point relMouse = new Point(mousepos.x - gui.guiLeft, mousepos.y - gui.guiTop);
+            /*Point relMouse = new Point(mousepos.x - gui.guiLeft, mousepos.y - gui.guiTop);
 
             Point center = new Point(87, 49);
 
@@ -103,7 +103,7 @@ public class MystTooltipHandler implements IContainerInputHandler, IContainerToo
                     GuiUsageRecipe.openRecipeGui("inkmixer");
                     return true;
                 }
-            }
+            }*/
         }
 
         return false;
@@ -122,7 +122,7 @@ public class MystTooltipHandler implements IContainerInputHandler, IContainerToo
     public boolean mouseClicked(GuiContainer gui, int mousex, int mousey, int button) {
         if (Integrator.guiWritingDeskClass.isAssignableFrom(gui.getClass())) {
             Point mousepos = GuiDraw.getMousePosition();
-            Point relMouse = new Point(mousepos.x - gui.guiLeft, mousepos.y - gui.guiTop);
+            /*Point relMouse = new Point(mousepos.x - gui.guiLeft, mousepos.y - gui.guiTop);
 
             Rectangle rect = new Rectangle(156 + 228, 45, 18, 34);
 
@@ -134,10 +134,10 @@ public class MystTooltipHandler implements IContainerInputHandler, IContainerToo
                     GuiUsageRecipe.openRecipeGui("writingdesk");
                     return true;
                 }
-            }
+            }*/
         } else if (Integrator.guiInkMixerClass.isAssignableFrom(gui.getClass())) {
             Point mousepos = GuiDraw.getMousePosition();
-            Point relMouse = new Point(mousepos.x - gui.guiLeft, mousepos.y - gui.guiTop);
+            /*Point relMouse = new Point(mousepos.x - gui.guiLeft, mousepos.y - gui.guiTop);
 
             Point center = new Point(87, 49);
 
@@ -149,10 +149,10 @@ public class MystTooltipHandler implements IContainerInputHandler, IContainerToo
                     GuiUsageRecipe.openRecipeGui("inkmixer");
                     return true;
                 }
-            }
+            }*/
         } else if (gui instanceof GuiRecipe) {
             Point mousepos = GuiDraw.getMousePosition();
-            Point relMouse = new Point(mousepos.x - gui.guiLeft, mousepos.y - gui.guiTop);
+            /*Point relMouse = new Point(mousepos.x - gui.guiLeft, mousepos.y - gui.guiTop);
 
             GuiRecipe guiRecipe = (GuiRecipe) gui;
 
@@ -168,7 +168,7 @@ public class MystTooltipHandler implements IContainerInputHandler, IContainerToo
                         return true;
                     }
                 }
-            }
+            }*/
         }
         return false;
     }

--- a/src/main/java/me/heldplayer/plugins/nei/mystcraft/client/MystTooltipHandler.java
+++ b/src/main/java/me/heldplayer/plugins/nei/mystcraft/client/MystTooltipHandler.java
@@ -20,7 +20,7 @@ public class MystTooltipHandler implements IContainerInputHandler, IContainerToo
 
     @Override
     public List<String> handleTooltip(GuiContainer gui, int mousex, int mousey, List<String> currenttip) {
-        /*if (ModuleTooltips.recipesTooltips && Integrator.guiWritingDeskClass.isAssignableFrom(gui.getClass())) {
+        if (ModuleTooltips.recipesTooltips && Integrator.guiWritingDeskClass.isAssignableFrom(gui.getClass())) {
             Point mousepos = GuiDraw.getMousePosition();
             Point relMouse = new Point(mousepos.x - gui.guiLeft, mousepos.y - gui.guiTop);
 
@@ -38,7 +38,7 @@ public class MystTooltipHandler implements IContainerInputHandler, IContainerToo
             if (currenttip.isEmpty() && GuiContainerManager.shouldShowTooltip(gui) && center.distance(relMouse) < 34.0D) {
                 currenttip.add(StatCollector.translateToLocal("nei.mystcraft.recipes"));
             }
-        }*/
+        }
         return currenttip;
     }
 
@@ -51,9 +51,9 @@ public class MystTooltipHandler implements IContainerInputHandler, IContainerToo
     public List<String> handleItemTooltip(GuiContainer gui, ItemStack stack, int mouseX, int mouseY, List<String> currenttip) {
         if (gui instanceof GuiRecipe) {
             Point mousepos = new Point(mouseX, mouseY);
-            /*Point relMouse = new Point(mousepos.x - gui.guiLeft, mousepos.y - gui.guiTop);
+            Point relMouse = new Point(mousepos.x - gui.guiLeft, mousepos.y - gui.guiTop);
 
-            GuiRecipe guiRecipe = (GuiRecipe) gui;
+            GuiRecipe<?> guiRecipe = (GuiRecipe<?>) gui;
 
             if (currenttip.isEmpty() && GuiContainerManager.shouldShowTooltip(gui)) {
                 if (ModuleTooltips.recipesTooltips && guiRecipe.currenthandlers.get(guiRecipe.recipetype) instanceof WritingDeskRecipeHandler) {
@@ -67,7 +67,7 @@ public class MystTooltipHandler implements IContainerInputHandler, IContainerToo
                         currenttip.add(StatCollector.translateToLocal("nei.mystcraft.recipes"));
                     }
                 }
-            }*/
+            }
         }
         return currenttip;
     }
@@ -76,7 +76,7 @@ public class MystTooltipHandler implements IContainerInputHandler, IContainerToo
     public boolean keyTyped(GuiContainer gui, char keyChar, int keyCode) {
         if (Integrator.guiWritingDeskClass.isAssignableFrom(gui.getClass())) {
             Point mousepos = GuiDraw.getMousePosition();
-            /*Point relMouse = new Point(mousepos.x - gui.guiLeft, mousepos.y - gui.guiTop);
+            Point relMouse = new Point(mousepos.x - gui.guiLeft, mousepos.y - gui.guiTop);
 
             Rectangle rect = new Rectangle(156 + 228, 45, 18, 34);
 
@@ -88,10 +88,10 @@ public class MystTooltipHandler implements IContainerInputHandler, IContainerToo
                     GuiUsageRecipe.openRecipeGui("writingdesk");
                     return true;
                 }
-            }*/
+            }
         } else if (Integrator.guiInkMixerClass.isAssignableFrom(gui.getClass())) {
             Point mousepos = GuiDraw.getMousePosition();
-            /*Point relMouse = new Point(mousepos.x - gui.guiLeft, mousepos.y - gui.guiTop);
+            Point relMouse = new Point(mousepos.x - gui.guiLeft, mousepos.y - gui.guiTop);
 
             Point center = new Point(87, 49);
 
@@ -103,7 +103,7 @@ public class MystTooltipHandler implements IContainerInputHandler, IContainerToo
                     GuiUsageRecipe.openRecipeGui("inkmixer");
                     return true;
                 }
-            }*/
+            }
         }
 
         return false;
@@ -122,7 +122,7 @@ public class MystTooltipHandler implements IContainerInputHandler, IContainerToo
     public boolean mouseClicked(GuiContainer gui, int mousex, int mousey, int button) {
         if (Integrator.guiWritingDeskClass.isAssignableFrom(gui.getClass())) {
             Point mousepos = GuiDraw.getMousePosition();
-            /*Point relMouse = new Point(mousepos.x - gui.guiLeft, mousepos.y - gui.guiTop);
+            Point relMouse = new Point(mousepos.x - gui.guiLeft, mousepos.y - gui.guiTop);
 
             Rectangle rect = new Rectangle(156 + 228, 45, 18, 34);
 
@@ -134,10 +134,10 @@ public class MystTooltipHandler implements IContainerInputHandler, IContainerToo
                     GuiUsageRecipe.openRecipeGui("writingdesk");
                     return true;
                 }
-            }*/
+            }
         } else if (Integrator.guiInkMixerClass.isAssignableFrom(gui.getClass())) {
             Point mousepos = GuiDraw.getMousePosition();
-            /*Point relMouse = new Point(mousepos.x - gui.guiLeft, mousepos.y - gui.guiTop);
+            Point relMouse = new Point(mousepos.x - gui.guiLeft, mousepos.y - gui.guiTop);
 
             Point center = new Point(87, 49);
 
@@ -149,12 +149,12 @@ public class MystTooltipHandler implements IContainerInputHandler, IContainerToo
                     GuiUsageRecipe.openRecipeGui("inkmixer");
                     return true;
                 }
-            }*/
+            }
         } else if (gui instanceof GuiRecipe) {
             Point mousepos = GuiDraw.getMousePosition();
-            /*Point relMouse = new Point(mousepos.x - gui.guiLeft, mousepos.y - gui.guiTop);
+            Point relMouse = new Point(mousepos.x - gui.guiLeft, mousepos.y - gui.guiTop);
 
-            GuiRecipe guiRecipe = (GuiRecipe) gui;
+            GuiRecipe<?> guiRecipe = (GuiRecipe<?>) gui;
 
             if (guiRecipe.currenthandlers.get(guiRecipe.recipetype) instanceof WritingDeskRecipeHandler) {
                 Rectangle rect = new Rectangle(151, 34, 18, 34);
@@ -168,7 +168,7 @@ public class MystTooltipHandler implements IContainerInputHandler, IContainerToo
                         return true;
                     }
                 }
-            }*/
+            }
         }
         return false;
     }

--- a/src/main/java/me/heldplayer/plugins/nei/mystcraft/client/WritingDeskRecipeHandler.java
+++ b/src/main/java/me/heldplayer/plugins/nei/mystcraft/client/WritingDeskRecipeHandler.java
@@ -231,7 +231,8 @@ public class WritingDeskRecipeHandler extends TemplateRecipeHandler {
         return 1;
     }
 
-    public List<String> handleItemTooltip(GuiRecipe gui, ItemStack stack, List<String> currenttip, int recipeId, int recipeId2) {
+    @Override
+    public List<String> handleItemTooltip(GuiRecipe<?> gui, ItemStack stack, List<String> currenttip, int recipeId) {
         CachedWritingDeskRecipe recipe = (CachedWritingDeskRecipe) this.arecipes.get(recipeId);
 
         currenttip = super.handleItemTooltip(gui, stack, currenttip, recipeId);

--- a/src/main/java/me/heldplayer/plugins/nei/mystcraft/client/WritingDeskRecipeHandler.java
+++ b/src/main/java/me/heldplayer/plugins/nei/mystcraft/client/WritingDeskRecipeHandler.java
@@ -231,14 +231,13 @@ public class WritingDeskRecipeHandler extends TemplateRecipeHandler {
         return 1;
     }
 
-    @Override
-    public List<String> handleItemTooltip(GuiRecipe gui, ItemStack stack, List<String> currenttip, int recipeId) {
+    public List<String> handleItemTooltip(GuiRecipe gui, ItemStack stack, List<String> currenttip, int recipeId, int recipeId2) {
         CachedWritingDeskRecipe recipe = (CachedWritingDeskRecipe) this.arecipes.get(recipeId);
 
         currenttip = super.handleItemTooltip(gui, stack, currenttip, recipeId);
 
         Point mousepos = GuiDraw.getMousePosition();
-        Point relMouse = new Point(mousepos.x - gui.guiLeft, mousepos.y - gui.guiTop);
+        /*Point relMouse = new Point(mousepos.x - gui.guiLeft, mousepos.y - gui.guiTop);
 
         if (recipe.isNotebook) {
             if (currenttip.isEmpty() && stack == null && new Rectangle(42, 19, 33, 44).contains(relMouse)) {
@@ -286,7 +285,7 @@ public class WritingDeskRecipeHandler extends TemplateRecipeHandler {
                     currenttip.add(StatCollector.translateToLocal("nei.mystcraft.writingdesk.page"));
                 }
             }
-        }
+        }*/
         return currenttip;
     }
 

--- a/src/main/java/me/heldplayer/plugins/nei/mystcraft/client/WritingDeskRecipeHandler.java
+++ b/src/main/java/me/heldplayer/plugins/nei/mystcraft/client/WritingDeskRecipeHandler.java
@@ -238,7 +238,7 @@ public class WritingDeskRecipeHandler extends TemplateRecipeHandler {
         currenttip = super.handleItemTooltip(gui, stack, currenttip, recipeId);
 
         Point mousepos = GuiDraw.getMousePosition();
-        /*Point relMouse = new Point(mousepos.x - gui.guiLeft, mousepos.y - gui.guiTop);
+        Point relMouse = new Point(mousepos.x - gui.guiLeft, mousepos.y - gui.guiTop);
 
         if (recipe.isNotebook) {
             if (currenttip.isEmpty() && stack == null && new Rectangle(42, 19, 33, 44).contains(relMouse)) {
@@ -286,7 +286,7 @@ public class WritingDeskRecipeHandler extends TemplateRecipeHandler {
                     currenttip.add(StatCollector.translateToLocal("nei.mystcraft.writingdesk.page"));
                 }
             }
-        }*/
+        }
         return currenttip;
     }
 

--- a/src/main/java/me/heldplayer/plugins/nei/mystcraft/modules/ModuleItemSubsets.java
+++ b/src/main/java/me/heldplayer/plugins/nei/mystcraft/modules/ModuleItemSubsets.java
@@ -164,10 +164,10 @@ public class ModuleItemSubsets implements IModule {
     @Override
     public void disable() {
         if (this.enabled) {
-            SubsetWidget.SubsetTag root = ReflectionHelper.getPrivateValue(SubsetWidget.class, null, "root");
+            /*SubsetWidget.SubsetTag root = ReflectionHelper.getPrivateValue(SubsetWidget.class, null, "root");
             synchronized (root) {
                 root.children.remove("mystcraft");
-            }
+            }*/
 
             this.enabled = false;
         }

--- a/src/main/resources/META-INF/spacore_at.cfg
+++ b/src/main/resources/META-INF/spacore_at.cfg
@@ -1,0 +1,27 @@
+# GuiContainer
+#public bdd.i #FD:GuiContainer/field_147003_i #guiLeft
+#public bdd.r #FD:GuiContainer/field_147009_r #guiTop
+public net.minecraft.client.gui.inventory.GuiContainer field_147003_i #guiLeft
+public net.minecraft.client.gui.inventory.GuiContainer field_147009_r #guiTop
+
+# GuiScreen
+public net.minecraft.client.gui.GuiScreen field_146292_n #buttonList
+public net.minecraft.client.gui.GuiScreen field_146287_f #eventButton
+public net.minecraft.client.gui.GuiScreen field_146288_g #lastMouseEvent
+public net.minecraft.client.gui.GuiScreen field_146298_h
+
+# GuiButton
+public net.minecraft.client.gui.GuiButton field_146120_f #width
+public net.minecraft.client.gui.GuiButton field_146121_g #height
+
+# MinecraftServer
+public net.minecraft.server.MinecraftServer field_71308_o #anvilFile
+
+#OpenGlHelper
+public net.minecraft.client.renderer.OpenGlHelper *
+
+#EntityRenderer
+public net.minecraft.client.renderer.EntityRenderer func_78467_g(F)V #orientCamera
+
+#TextureMap
+public net.minecraft.client.renderer.texture.TextureMap func_110573_f()V # registerIcons


### PR DESCRIPTION
As seen here, https://github.com/GTNewHorizons/NotEnoughItems/issues/596, I fixed a Minecraft crash (with NotEnoughItems GTNH) and a few compile errors in your Mystcraft NEI Plugin. 

I am wanting to eventually redistribute my fixed version of the Mystcraft NEI Plugin (for use in modpacks), however it seems I found out I cannot do so because under [CurseForge](https://www.curseforge.com/minecraft/mc-mods/nei-mystcraft-plugin) your project is listed as All Rights Reserved.

Even on Github where it says the project is under the [LPPL-1.3c license](https://github.com/heldplayer/mystcraft-nei-plugin#LPPL-1.3c-1-ov-file), someone can only redistribute unmodified versions, unless they are named as "current maintainer".

So would you be able to designate me as the "Current Maintainer" which would solve this potential licensing headache? And maybe update this on CurseForge to the same license as Github?

Thanks,

Jonius7